### PR TITLE
create a bin for executing the rewrite proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.1.1"></a>
+## [1.1.1](https://github.com/npm/couch-url-rewrite-proxy/compare/v1.1.0...v1.1.1) (2016-07-07)
+
+
+### Bug Fixes
+
+* also add req param parsing ([ee8ae12](https://github.com/npm/couch-url-rewrite-proxy/commit/ee8ae12))
+* need body-parser dependency TODO: add test for post ([fd0d821](https://github.com/npm/couch-url-rewrite-proxy/commit/fd0d821))
+
+
+
 <a name="1.1.0"></a>
 # [1.1.0](https://github.com/npm/couch-url-rewrite-proxy/compare/v1.0.0...v1.1.0) (2016-07-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.1.0"></a>
+# [1.1.0](https://github.com/npm/couch-url-rewrite-proxy/compare/v1.0.0...v1.1.0) (2016-07-07)
+
+
+### Features
+
+* add bin for running proxy ([5aa60ca](https://github.com/npm/couch-url-rewrite-proxy/commit/5aa60ca))
+* proxy now rewrites package JSON as it is served ([#3](https://github.com/npm/couch-url-rewrite-proxy/issues/3)) ([5870a75](https://github.com/npm/couch-url-rewrite-proxy/commit/5870a75))
+* route tarballs directly through to the client ([#2](https://github.com/npm/couch-url-rewrite-proxy/issues/2)) ([a071e6c](https://github.com/npm/couch-url-rewrite-proxy/commit/a071e6c))
+
+
+
 <a name="1.0.0"></a>
 # 1.0.0 (2016-06-23)
 

--- a/bin/couch-url-rewrite-proxy.js
+++ b/bin/couch-url-rewrite-proxy.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const proxy = require('../server')
+
+require('yargs')
+  .command(
+    'start',
+    'start the registry URL rewrite proxy',
+    function (yargs) {
+      return yargs
+        .option('port', {
+          alias: 'p',
+          default: 8080,
+          describe: 'what port should the proxy run on'
+        })
+        .option('upstream', {
+          alias: 'u',
+          default: 'http://127.0.0.1:9999',
+          describe: 'what upstream should the proxy connect to'
+        })
+        .option('front-door-host', {
+          alias: 'f',
+          default: process.env.FRONT_DOOR_HOST || 'https://registry.example.com',
+          describe: 'what external URL should tarball URLs be rewritten to'
+        })
+    },
+    function (argv) {
+      proxy(argv)
+    }
+  )
+  .help()
+  .alias('help', 'h')
+  .demand(1, 'please provide a command to run')
+  .argv

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/couch-url-rewrite-proxy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a proxy that rewrites URLs on their way out of couch, making registry migrations easier",
   "main": "server.js",
   "bin": "bin/couch-url-rewrite-proxy.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "a proxy that rewrites URLs on their way out of couch, making registry migrations easier",
   "main": "server.js",
+  "bin": "bin/couch-url-rewrite-proxy.js",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "pretest": "standard",
@@ -37,6 +38,7 @@
   "dependencies": {
     "@npm/npm-urls": "^1.0.1",
     "express": "^4.14.0",
-    "request": "^2.72.0"
+    "request": "^2.72.0",
+    "yargs": "^4.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/couch-url-rewrite-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "a proxy that rewrites URLs on their way out of couch, making registry migrations easier",
   "main": "server.js",
   "bin": "bin/couch-url-rewrite-proxy.js",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@npm/npm-urls": "^1.0.1",
+    "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "request": "^2.72.0",
     "yargs": "^4.7.1"

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ var npmUrls = require('@npm/npm-urls')
 var url = require('url')
 
 app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: false }))
 
 function CouchUrlRewriteProxy (opts) {
   function proxy (req, res, next) {

--- a/server.js
+++ b/server.js
@@ -9,9 +9,11 @@ function CouchUrlRewriteProxy (opts) {
   function proxy (req, res, next) {
     var payload = {
       method: req.method,
-      url: url.resolve(opts.frontDoorHost, req.path),
+      url: url.resolve(opts.upstream, req.path),
       headers: req.headers,
-      qs: req.query
+      qs: req.query,
+      gzip: true,
+      strictSSL: false
     }
     req.headers.host = 'registry.npmjs.org'
 
@@ -58,7 +60,10 @@ function rewriteUrls (res, status, body, frontDoorHost) {
 }
 
 module.exports = function (opts, cb) {
+  cb = cb || function () {}
   CouchUrlRewriteProxy(opts)
+  console.info('routing', opts.port, 'to', opts.upstream)
+  console.info('rewriting to FRONT_DOOR_HOST =', opts.frontDoorHost)
   var server = app.listen(opts.port, function () {
     console.info('listening on ', opts.port)
     return cb(undefined, server)

--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
 var express = require('express')
 
 var app = express()
+var bodyParser = require('body-parser')
 var request = require('request')
 var npmUrls = require('@npm/npm-urls')
 var url = require('url')
+
+app.use(bodyParser.json())
 
 function CouchUrlRewriteProxy (opts) {
   function proxy (req, res, next) {
@@ -12,7 +15,7 @@ function CouchUrlRewriteProxy (opts) {
       url: url.resolve(opts.upstream, req.path),
       headers: req.headers,
       qs: req.query,
-      gzip: true,
+      json: true,
       strictSSL: false
     }
     req.headers.host = 'registry.npmjs.org'
@@ -50,13 +53,11 @@ function CouchUrlRewriteProxy (opts) {
 
 function rewriteUrls (res, status, body, frontDoorHost) {
   try {
-    var json = JSON.parse(body)
-    npmUrls.rewriteOldTarballUrls(frontDoorHost, json)
-    res.status(status).send(JSON.stringify(json))
+    npmUrls.rewriteOldTarballUrls(frontDoorHost, body)
   } catch (err) {
     console.error(err.message)
-    res.status(status).send(body)
   }
+  res.status(status).send(body)
 }
 
 module.exports = function (opts, cb) {

--- a/test/couch-url-rewrite-proxy.js
+++ b/test/couch-url-rewrite-proxy.js
@@ -17,6 +17,7 @@ describe('couch-url-rewrite-proxy', function () {
   before(function (done) {
     proxy({
       port: 9999,
+      upstream: 'http://www.example.com',
       frontDoorHost: 'http://www.example.com'
     }, function (err, _server) {
       if (err) return done(err)


### PR DESCRIPTION
- [x] create a `bin/` for running the rewrite proxy.
- [x] manually test the rewrite proxy.
- [x] publish a version of the module, and test it with npm Enterprise.