### PR TITLE
fix: pipe _changes directly through to upstream server

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ function CouchUrlRewriteProxy (opts) {
     var rewrite
     if (
       !req.path.match(/\/-\//) && // CouchDB API URLs.
+      !req.path.match(/\/_changes\/?/) && // Changes feed.
       !req.path.match(/\.tgz$/) && // tarball URLs.
       req.method === 'GET' // we should only rewrite GET requests!
     ) {


### PR DESCRIPTION
The last patch only half solved the underlying problem, we should not be applying a transformation to the changes feed.