### PR TITLE
fix: redact fields that should not be stored in CouchDB

### DIFF
--- a/lib/redact.js
+++ b/lib/redact.js
@@ -1,0 +1,17 @@
+// redact fields from package.json that should have been obfuscated.
+const redactSSORegex = /"sso":\s*"[^"]*"/g
+const replacement = '[SECRET]'
+
+module.exports = function (body) {
+  if (isPackageJson(body)) {
+    return body.replace(redactSSORegex, `"sso":"${replacement}"`)
+  }
+}
+
+// detect whether or not this payload is
+// package meta information vs., as an example,
+// the login dance.
+function isPackageJson (body) {
+  // checking for "name" and "versions", this should be sufficient.
+  return body.indexOf('"name"') !== -1 && body.indexOf('"versions"') !== -1
+}

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const app = express()
 const bodyParser = require('body-parser')
 const request = require('request')
 const replify = require('replify')
+const redact = require('./lib/redact')
 const rewrite = require('./lib/rewrite')
 
 const url = require('url')
@@ -66,7 +67,7 @@ function CouchUrlRewriteProxy (opts) {
 
 function rewriteUrls (res, status, body, frontDoorHost) {
   try {
-    body = rewrite(body, frontDoorHost)
+    body = rewrite(redact(body), frontDoorHost)
   } catch (err) {
     console.error(err.message)
   }

--- a/test/fixtures/should-redact.json
+++ b/test/fixtures/should-redact.json
@@ -1,0 +1,67 @@
+{
+  "_id": "tiny-tarball",
+  "_rev": "3-085759e977d42299e64a35aedc17d250",
+  "name": "tiny-tarball",
+  "description": "tiny tarball used for health checks",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "tiny-tarball",
+      "version": "1.0.0",
+      "description": "tiny tarball used for health checks",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "Ben Coe",
+        "email": "ben@npmjs.com"
+      },
+      "license": "ISC",
+      "_id": "tiny-tarball@1.0.0",
+      "_shasum": "bbf102d5ae73afe2c553295e0fb02230216f65b1",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "1.5.0",
+      "_npmUser": {
+        "name": "bcoe",
+        "email": "bencoe@gmail.com",
+        "sso": "http://very-secret-url"
+      },
+      "maintainers": [
+        {
+          "sso": "http://very-secret-url",
+          "name": "bcoe",
+          "email": "bencoe@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bbf102d5ae73afe2c553295e0fb02230216f65b1",
+        "tarball": "https://registry.npmjs.org/tiny-tarball/-/tiny-tarball-1.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# TinyTarball\n\ntiny-tarball used for health checks\n\n**don't unpublish me!**\n",
+  "maintainers": [
+    {
+      "sso": "http://very-secret-url",
+      "name": "bcoe",
+      "email": "ben@npmjs.com"
+    }
+  ],
+  "time": {
+    "modified": "2015-05-16T22:27:54.741Z",
+    "created": "2015-03-24T00:12:24.039Z",
+    "1.0.0": "2015-03-24T00:12:24.039Z"
+  },
+  "author": {
+    "name": "Ben Coe",
+    "email": "ben@npmjs.com"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}


### PR DESCRIPTION
in the past, we have accidentally stored fields in CouchDB from the user object that contains secrets. In registry-frontdoor, we've fixed this by black-listing these fields on the user object.

Unfortunately, we would need to backwards migrate CouchDB to fix this issue in old data, which is a pretty large task -- this pull request instead introduces this process of black-listing to the rewrite proxy that sits in front of serving package JSON.